### PR TITLE
split encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,24 +1659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "shout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da52815e30470d826ffd393735c3a179fc8e5b965a2210c4c66dcf66960faec7"
-dependencies = [
- "shout-sys",
-]
-
-[[package]]
-name = "shout-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b68fb7f29ef17f9b5cdaa7e224e5464606b0709f48e916b1678327146a26535"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,7 +1693,6 @@ dependencies = [
  "regex",
  "ringbuf",
  "serde",
- "shout",
  "thiserror 2.0.16",
  "toml",
  "tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ opusenc = {git = "https://github.com/vsandstrom/opusenc-rs", branch = "homebrew_
 regex = "1.11.1"
 ringbuf = "0.4.8"
 serde = { version = "1.0.219", features = ["derive"] }
-shout = "0.2.1"
+# shout = "0.2.1"
 thiserror = "2.0.16"
 toml = "0.9.5"
 tungstenite = { version = "0.27.0", features = ["native-tls"] }

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -5,9 +5,9 @@ use crate::config::TauConfigError;
 use is_ip::is_ip;
 
 #[derive(Parser)]
-#[command(name = "Tau")]
-#[command(version = "0.0.1")]
-#[command( about = "Hijacks chosen audio device, encodes audio into Ogg Opus and streams to IceCast server")]
+#[command(name = "tau-radio")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command( about = "Hijacks chosen audio device, encodes audio into Ogg Opus and streams to webradio server [tau-tower]")]
 pub(crate) struct Args {
     /// IceCast server username
     #[arg(long)]
@@ -27,9 +27,6 @@ pub(crate) struct Args {
     })]
     pub port: Option<u16>,
 
-    #[arg(short, long)]
-    pub mount: Option<String>,
-
     /// Optional custom filename of local copy
     #[arg(short, long)]
     pub file: Option<String>,
@@ -38,9 +35,11 @@ pub(crate) struct Args {
     #[arg(long)]
     pub no_recording: bool,
 
+    /// Output directory [default: $HOME/tau/recordings/]
     #[arg(short, long)]
     pub output: Option<String>,
 
+    /// Resets config.toml 
     #[arg(long)]
     pub reset_config: bool,
     // #[arg(long, value_parser=validate_stream_type)]

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -5,25 +5,6 @@ use cpal::{
     Device, Host,
     traits::{DeviceTrait, HostTrait},
 };
-use shout::{ShoutConn, ShoutConnBuilder};
-
-pub fn create_icecast_connection(config: Config) -> anyhow::Result<ShoutConn> {
-  match ShoutConnBuilder::new()
-    .host(config.ip.clone())
-    .port(config.port)
-    .user(config.username.clone())
-    .password(config.password.clone())
-    .mount(config.mount)
-    .protocol(shout::ShoutProtocol::HTTP)
-    .format(shout::ShoutFormat::Ogg)
-    .build()
-  {
-    Ok(shout) => Ok(shout),
-    Err(e) => Err(anyhow::anyhow!(
-      "Could not connect to the IceCast host: {e:?}"
-    )),
-  }
-}
 
 pub fn find_audio_device(host: &Host, config: &Config) -> anyhow::Result<Device> {
   let devices = host.input_devices().map_err(|err| {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,10 +11,8 @@ pub struct Config {
     pub ip: String,
     pub broadcast_port: u16,
     pub port: u16,
-    pub mount: String,
     pub audio_interface: String,
     pub file: Option<String>,
-    // pub no_recording: bool
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -50,24 +48,11 @@ impl Config {
 
   /// Merges local config.toml with current CLI arguments if there are any.
   pub fn merge_cli_args(mut self, args: &crate::args::Args) -> Self {
-    if let Some(un) = &args.username {
-      self.username = un.to_string();
-    }
-    if let Some(pw) = &args.password {
-      self.password = pw.to_string();
-    }
-    if let Some(u) = &args.url {
-      self.ip = u.to_string();
-    }
-    if let Some(p) = args.port {
-      self.port = p;
-    }
-    if let Some(m) = &args.mount {
-      self.mount = m.to_string();
-    }
-    if let Some(f) = &args.file {
-      self.file = Some(f.to_string());
-    }
+    if let Some(un) = &args.username {self.username = un.to_string()}
+    if let Some(pw) = &args.password {self.password = pw.to_string()}
+    if let Some(u)  = &args.url      {self.ip       = u.to_string()}
+    if let Some(p)      = args.port      {self.port     = p}
+    if let Some(f)  = &args.file     {self.file     = Some(f.to_string())}
     self
   }
 
@@ -122,12 +107,6 @@ impl Config {
         .map_err(|e| TauConfigError::Input(e.to_string()))
         .and_then(validate_port)?;
 
-      let mount = Input::new()
-        .with_prompt("Broadcast mount point")
-        .default("tau.ogg".into())
-        .interact_text()
-        .map_err(|e| TauConfigError::Input(e.to_string()))?;
-
       let audio_interface = Input::new()
         .with_prompt("Audio Interface")
         .default(crate::DEFAULT_INPUT.to_string())
@@ -146,7 +125,6 @@ impl Config {
         ip,
         port,
         broadcast_port,
-        mount,
         audio_interface,
         file: if file.trim().is_empty() {
           None

--- a/src/threads/icecast/mod.rs
+++ b/src/threads/icecast/mod.rs
@@ -1,4 +1,5 @@
 use crate::DEFAULT_CH;
+use crate::Config;
 
 use std::{
     path::PathBuf,
@@ -8,7 +9,7 @@ use std::{
 };
 
 use ringbuf::traits::Consumer;
-use shout::ShoutConn;
+use shout::{ShoutConn, ShoutConnBuilder};
 use super::{create_encoder, create_recorder};
 
 /// Spawns a thread producing a continuous stream to IceCast host,
@@ -95,4 +96,22 @@ pub fn rec_thread(
       }
     }
   })
+}
+
+pub fn create_icecast_connection(config: Config) -> anyhow::Result<ShoutConn> {
+  match ShoutConnBuilder::new()
+    .host(config.ip.clone())
+    .port(config.port)
+    .user(config.username.clone())
+    .password(config.password.clone())
+    .mount(config.mount)
+    .protocol(shout::ShoutProtocol::HTTP)
+    .format(shout::ShoutFormat::Ogg)
+    .build()
+  {
+    Ok(shout) => Ok(shout),
+    Err(e) => Err(anyhow::anyhow!(
+      "Could not connect to the IceCast host: {e:?}"
+    )),
+  }
 }

--- a/src/threads/mod.rs
+++ b/src/threads/mod.rs
@@ -1,6 +1,6 @@
 pub mod ws;
-pub mod udp;
-pub mod icecast;
+// pub mod udp;
+// pub mod icecast;
 
 use crate::{DEFAULT_CH, DEFAULT_SR};
 use std::{

--- a/src/threads/ws/mod.rs
+++ b/src/threads/ws/mod.rs
@@ -1,13 +1,9 @@
 use crate::{threads::create_recorder, Credentials, DEFAULT_CH};
 use std::{
-    path::Path,
-    net::{SocketAddr, TcpStream},
-    sync::{atomic::{AtomicBool, Ordering}, Arc},
-    thread::{sleep, spawn, JoinHandle},
-    time::Duration,
+    net::{SocketAddr, TcpStream}, path::{Path, PathBuf}, sync::{atomic::{AtomicBool, Ordering}, Arc}, thread::{sleep, spawn}, time::Duration
 };
 
-use crossbeam::channel::{Receiver, bounded};
+use crossbeam::channel::{Receiver, bounded, Sender};
 use ringbuf::traits::Consumer;
 use tungstenite::{connect, http::Uri, stream::MaybeTlsStream, ClientRequestBuilder, Message, WebSocket};
 
@@ -18,85 +14,27 @@ pub fn thread(
     url: SocketAddr,
     filename: Arc<String>,
     credentials: Credentials,
-    shutdown: Receiver<()>
-) -> JoinHandle<()> {
+    shutdown: Arc<AtomicBool>
+) {
   let framesize = 960 * DEFAULT_CH;
-  let mut opus_frame_buffer = Vec::with_capacity(framesize);
   let (opus_tx, opus_rx) = bounded::<Vec<u8>>(4096 * 32);
+  let (audio_tx, audio_rx) = bounded::<f32>(4096 * 32);
 
-  // let (mut opus_tx, opus_rx) = ringbuf::HeapRb::new(256).split();
-  let connected = Arc::new(AtomicBool::new(false));
-  let shutdown2 = shutdown.clone();
-
-  // Encoding thread
-  let encoder_thread = spawn(move || {
-    let mut encoder = create_encoder(&filename);
-    loop {
-      if shutdown2.try_recv().is_ok() { break; }
-      if let Some(sample) = rx.try_pop() {
-        opus_frame_buffer.push(sample);
-      } else {
-        sleep(Duration::from_millis(2));
-      }
-
-      if opus_frame_buffer.len() == framesize {
-        encoder
-          .write_float(&opus_frame_buffer)
-          .expect("block not a multiple of input channels");
-        opus_frame_buffer.clear();
-        // flush forces encoder to return a page, even if not ready.
-        // true is used when realtime streaming is more important than stability.
-        if let Some(page) = encoder.get_page(true) {
-          // TODO: NO SOUND IS GETTING THROUGH HERE
-          if let Err(e) = opus_tx.send(page.to_vec()) {
-            eprint!(
-                  " \
-            Could not append encoded ogg to shared \
-            ringbuffer to websocket thread: {e}"
-            );
-            break;
-            // exit(1);
-          }
-        }
-      }
-    }
+  let shutdown_clone = shutdown.clone();
+  let audio_capture_thread = spawn(move || {
+    audio_capture_loop(shutdown_clone, &mut rx, &[audio_tx]);
   });
 
+  let shutdown_clone = shutdown.clone();
+  // Encoding thread
+  let encoder_thread = spawn(move || {
+    encode_audio(shutdown_clone, filename, &audio_rx, &opus_tx, framesize);
+  });
 
-  let uri = Uri::builder()
-    .scheme("ws")
-    .authority(format!("{}:{}", url.ip(), url.port()))
-    .path_and_query("/")
-    .build()
-    .unwrap();
+  websocket_connect_loop(shutdown, &opus_rx, &url, &credentials);
 
-  loop {
-    if shutdown.try_recv().is_ok() { break; }
-    if !connected.load(Ordering::SeqCst) {
-      let request = ClientRequestBuilder::new(uri.clone())
-        .with_header("password", credentials.password.clone())
-        .with_header("username", credentials.username.clone())
-        .with_header("port", credentials.broadcast_port.to_string());
-      match connect(request) {
-        Ok((mut ws, _)) => {
-          connected.store(true, Ordering::SeqCst);
-          let connected_inner = connected.clone();
-          let opus_rx_receiver = opus_rx.clone();
-          spawn(move || {
-            handle_websocket(&mut ws, &opus_rx_receiver);
-            connected_inner.store(false, Ordering::SeqCst);
-          });
-        }
-        Err(e) => {
-          eprintln!("HandshakeError: {e}");
-          sleep(std::time::Duration::from_millis(50));
-        }
-      }
-    } else {
-      sleep(std::time::Duration::from_millis(50));
-    }
-  }
-  encoder_thread
+  if let Err(e) = audio_capture_thread.join() { eprintln!("Audio capture join thread error: {e:?}") };
+  if let Err(e) = encoder_thread.join() { eprintln!("Encoder thread join error: {e:?}") };
 }
 
 pub fn rec_thread(
@@ -105,57 +43,131 @@ pub fn rec_thread(
     path: &Path,
     filename: Arc<String>,
     credentials: Credentials,
-    shutdown: Receiver<()>
-) -> JoinHandle<()> {
+    shutdown: Arc<AtomicBool>
+) {
+  let framesize = 960 * DEFAULT_CH;
   let (opus_tx, opus_rx) = bounded::<Vec<u8>>(4096 * 32);
-
-  // let (mut opus_tx, opus_rx) = ringbuf::HeapRb::new(256).split();
-  let connected = Arc::new(AtomicBool::new(false));
-  let shutdown2 = shutdown.clone();
+  let (encode_tx, encode_rx) = bounded::<f32>(4096 * 32);
+  let (record_tx, record_rx) = bounded::<f32>(4096 * 32);
   
-  let out_path = path.join(filename.clone().to_string());
+  let shutdown_clone = shutdown.clone();
+  let audio_capture_thread = spawn(move || {
+    audio_capture_loop(shutdown_clone, &mut rx, &[encode_tx, record_tx]);
+  });
 
+  let shutdown_clone = shutdown.clone();
+  let filename_clone = filename.clone();
   // Encoding thread
   let encoder_thread = spawn(move || {
-    let mut stream_encoder = create_encoder(&filename);
-    let mut local_encoder = create_recorder(&out_path, &filename);
-    let framesize = 960 * DEFAULT_CH;
-    let mut opus_frame_buffer = Vec::with_capacity(framesize);
-    loop {
-      if shutdown2.try_recv().is_ok() { break; }
-      if let Some(sample) = rx.try_pop() {
-        opus_frame_buffer.push(sample);
-      } else {
-        sleep(Duration::from_millis(2));
-      }
+    encode_audio(shutdown_clone, filename_clone, &encode_rx, &opus_tx, framesize);
+  });
 
-      if opus_frame_buffer.len() == framesize {
-        local_encoder
-          .write_float(&opus_frame_buffer)
-          .expect("block not a multiple of input channels");
-        stream_encoder
-          .write_float(&opus_frame_buffer)
-          .expect("block not a multiple of input channels");
-        opus_frame_buffer.clear();
-        // flush forces encoder to return a page, even if not ready.
-        // true is used when realtime streaming is more important than stability.
-        if let Some(page) = stream_encoder.get_page(true) {
-          // TODO: NO SOUND IS GETTING THROUGH HERE
-          if let Err(e) = opus_tx.send(page.to_vec()) {
-            eprint!(
-                  " \
-            Could not append encoded ogg to shared \
-            ringbuffer to websocket thread: {e}"
-            );
-            break;
-            // exit(1);
-          }
+  let filename_clone = filename.clone();
+  let shutdown_clone = shutdown.clone();
+  let out_path = path.join(filename.clone().to_string());
+  // Recording thread
+  let recorder_thread = spawn(move || {
+    record_audio(shutdown_clone, filename_clone, &record_rx, &out_path, framesize);
+  });
+
+  websocket_connect_loop(shutdown, &opus_rx, &url, &credentials);
+
+  if let Err(e) = audio_capture_thread.join() { eprintln!("Audio capture join thread error: {e:?}") };
+  if let Err(e) = recorder_thread.join() { eprintln!("Recorder thread join error: {e:?}") };
+  if let Err(e) = encoder_thread.join() { eprintln!("Encoder thread join error: {e:?}") };
+}
+
+fn handle_websocket(shutdown: Arc<AtomicBool>, ws: &mut WebSocket<MaybeTlsStream<TcpStream>>, rx: &Receiver<Vec<u8>>) {
+  'outer: loop {
+    while let Ok(page) = rx.recv() {
+      if shutdown.load(Ordering::SeqCst) { break 'outer; }
+      if let Err(e) = ws.send(Message::Binary(page.into())) {
+        eprintln!("Websocket send error: {e}");
+        return;
+      }
+    }
+  }
+}
+
+fn record_audio(
+  shutdown: Arc<AtomicBool>,
+  filename: Arc<String>,
+  in_rx: &Receiver<f32>,
+  path: &PathBuf,
+  framesize: usize
+) {
+  let mut encoder = create_recorder(path, &filename);
+  let mut buf = Vec::with_capacity(framesize);
+  loop {
+    if shutdown.load(Ordering::SeqCst) { break; }
+    if let Ok(sample) = in_rx.recv() {
+      buf.push(sample);
+    }
+    if buf.len() == framesize {
+      encoder
+        .write_float(&buf)
+        .expect("block not a multiple of input channels");
+      buf.clear();
+    }
+  }
+}
+
+fn encode_audio(
+  shutdown: Arc<AtomicBool>,
+  filename: Arc<String>,
+  in_rx: &Receiver<f32>,
+  opus_tx: &Sender<Vec<u8>>,
+  framesize: usize
+) {
+  let mut encoder = create_encoder(&filename);
+  let mut buf = Vec::with_capacity(framesize);
+  loop {
+    if shutdown.load(Ordering::SeqCst) { break; }
+    if let Ok(sample) = in_rx.recv() {
+      buf.push(sample);
+    }
+    if buf.len() == framesize {
+      encoder
+        .write_float(&buf)
+        .expect("block not a multiple of input channels");
+      buf.clear();
+      // flush forces encoder to return a page, even if not ready.
+      // true is used when realtime streaming is more important than stability.
+      if let Some(page) = encoder.get_page(true) {
+        // TODO: NO SOUND IS GETTING THROUGH HERE
+        if let Err(e) = opus_tx.send(page.to_vec()) {
+          eprint!(
+                " \
+          Could not append encoded ogg to shared \
+          ringbuffer to websocket thread: {e}"
+          );
+          break;
+          // exit(1);
         }
       }
     }
-  });
+  }
+}
 
 
+/// Fans out the audio stream to (optional) multiple consumers - Broadcast style!
+fn audio_capture_loop(shutdown: Arc<AtomicBool>, producer: &mut (impl Consumer<Item = f32> + Send + 'static), consumers: &[Sender<f32>]) {
+  loop {
+    if shutdown.load(Ordering::SeqCst) { break; }
+    if let Some(sample) = producer.try_pop() {
+      consumers.iter().for_each(|c| {
+        if let Err(e) = c.send(sample) {
+          eprintln!("Could not fan out audio stream: {e}")
+        }
+      });
+    } else {
+      sleep(Duration::from_millis(2));
+    }
+  }
+}
+
+fn websocket_connect_loop(shutdown: Arc<AtomicBool>, opus_rx: &Receiver<Vec<u8>>, url: &SocketAddr, credentials: &Credentials) {
+  let connected = Arc::new(AtomicBool::new(false));
   let uri = Uri::builder()
     .scheme("ws")
     .authority(format!("{}:{}", url.ip(), url.port()))
@@ -163,20 +175,22 @@ pub fn rec_thread(
     .build()
     .unwrap();
 
+  let request = ClientRequestBuilder::new(uri.clone())
+    .with_header("password", credentials.password.clone())
+    .with_header("username", credentials.username.clone())
+    .with_header("port", credentials.broadcast_port.to_string());
+
   loop {
-    if shutdown.try_recv().is_ok() { break; }
+    if shutdown.load(Ordering::SeqCst) { break; }
     if !connected.load(Ordering::SeqCst) {
-      let request = ClientRequestBuilder::new(uri.clone())
-        .with_header("password", credentials.password.clone())
-        .with_header("username", credentials.username.clone())
-        .with_header("port", credentials.broadcast_port.to_string());
-      match connect(request) {
+      match connect(request.clone()) {
         Ok((mut ws, _)) => {
           connected.store(true, Ordering::SeqCst);
           let connected_inner = connected.clone();
           let opus_rx_receiver = opus_rx.clone();
+          let shutdown_clone = shutdown.clone();
           spawn(move || {
-            handle_websocket(&mut ws, &opus_rx_receiver);
+            handle_websocket(shutdown_clone, &mut ws, &opus_rx_receiver);
             connected_inner.store(false, Ordering::SeqCst);
           });
         }
@@ -189,16 +203,5 @@ pub fn rec_thread(
       sleep(std::time::Duration::from_millis(50));
     }
   }
-  encoder_thread
-}
 
-fn handle_websocket(ws: &mut WebSocket<MaybeTlsStream<TcpStream>>, rx: &Receiver<Vec<u8>>) {
-  loop {
-    while let Ok(page) = rx.recv() {
-      if let Err(e) = ws.send(Message::Binary(page.into())) {
-        eprintln!("Websocket send error: {e}");
-        return;
-      }
-    }
-  }
 }


### PR DESCRIPTION
split encoding when saving a local copy.
cleanup and moved code into reusable fns